### PR TITLE
fix(recipe): No more memory leak when ChildrenWatch was stopped (#543)

### DIFF
--- a/kazoo/recipe/watchers.py
+++ b/kazoo/recipe/watchers.py
@@ -341,6 +341,8 @@ class ChildrenWatch(object):
                 if result is False:
                     self._stopped = True
                     self._func = None
+                    if self._allow_session_lost:
+                        self._client.remove_listener(self._session_watcher)
             except Exception as exc:
                 log.exception(exc)
                 raise


### PR DESCRIPTION
This ensures that the watcher is removed from the client listener when the func given to ChildrenWatch returns False.
Previously, the watcher was never removed so the ChildrenWatch object would endlessly grow in memory. A unit test is added to ensure this case never happen again.

Fix #542